### PR TITLE
Add policy renewal agent prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+
+# Generated assets
+comms/outreach_playbook.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# TCSAI
+# TCS AI Fridays Hackathon – Use Case 25
+
+This repository contains a prototype "Policy Renewal Agent" that helps insurers deliver personalized, human-like renewal conversations. The solution is designed to engage customers beyond automated reminders and to improve retention of digital-first segments.
+
+## Project Structure
+
+- `src/generate_synthetic_data.py` – script to generate synthetic customer and policy data aligned with the use case.
+- `src/policy_renewal_agent.py` – lightweight agent logic that blends segment strategies with channel-specific messaging templates.
+- `src/run_agent.py` – command-line entry point that turns a dataset into a channel-ready outreach playbook.
+- `configs/` – prompt templates and strategies used by the agent.
+- `data/` – synthetic datasets (generated).
+- `comms/` – personalized communication outputs produced by the agent.
+
+## Getting Started
+
+1. **Generate synthetic data** (optional if you want a different sample size):
+   ```bash
+   python src/generate_synthetic_data.py --size 200 --output data/synthetic_policy_customers.csv
+   ```
+2. **Create a personalized outreach playbook**:
+   ```bash
+   python src/run_agent.py --customers data/synthetic_policy_customers.csv --output comms/outreach_playbook.json
+   ```
+
+The resulting JSON file contains channel recommendations and tailored communication snippets for every customer.
+
+## Extending the Agent
+
+- Plug the playbook into local SLMs (e.g., Llama-3.2-3b-it) or Azure-hosted models for final copy polishing.
+- Replace or augment the templates and segment strategies with real product offers.
+- Add feedback loops by capturing response outcomes and retraining the incentives matrix.
+
+## Data Privacy
+
+All data included in this repository is synthetically generated for demonstration purposes only and contains no personally identifiable information.

--- a/comms/sample_outreach_playbook.json
+++ b/comms/sample_outreach_playbook.json
@@ -1,0 +1,23 @@
+[
+  {
+    "customer_id": "CUST-00001",
+    "channel": "Email",
+    "message": "Subject: Let's keep your Home Shield active, Avery Chen!\n\nHi Avery Chen,\n\nI noticed your Home Shield is set to renew on 2025-08-25. Because you're part of our Mid-Life Planners community, we've curated options that keep your premium at $1,833.41. Lock in your rate for the next 24 months and earn 1.5x reward points on timely payments.\n\nIf cost was a concern due to 'Switched providers', let's review flexible payment dates and see if a loyalty discount applies. Access a personalized dashboard comparing this year's coverage upgrades in the Renewal Hub.\n\nReply to this email or use the Renewal Hub link above to complete everything in a few minutes. I'm here if you'd prefer a quick call.\n\nWarm regards,\nPolicy Renewal Team",
+    "churn_risk": "0.60",
+    "engagement_score": "0.22"
+  },
+  {
+    "customer_id": "CUST-00002",
+    "channel": "SMS",
+    "message": "Kai Nakamura, your Business Guard renews on 2025-09-25. Lock in your rate for the next 24 months and earn 1.5x reward points on timely payments. Reply YES for a quick renewal link or call us if 'Forgot to renew' is still a concern.",
+    "churn_risk": "0.79",
+    "engagement_score": "0.21"
+  },
+  {
+    "customer_id": "CUST-00003",
+    "channel": "Phone",
+    "message": "Call Script:\n1. Greet Emma Johnson and confirm satisfaction with Comprehensive Auto.\n2. Acknowledge lapse reason: Premium too high.\n3. Share tailored offer: Qualify for a 10% loyalty credit and free annual policy reviews aligned with retirement milestones..\n4. Highlight Schedule a video check-in or chat with an advisor directly inside the portal. for self-service.\n5. Guide through renewal before 2025-10-23.",
+    "churn_risk": "0.41",
+    "engagement_score": "0.47"
+  }
+]

--- a/configs/channel_templates.json
+++ b/configs/channel_templates.json
@@ -1,0 +1,6 @@
+{
+  "Email": "Subject: Let's keep your {policy_type} active, {customer_name}!\n\nHi {customer_name},\n\nI noticed your {policy_type} is set to renew on {renewal_date}. Because you're part of our {segment} community, we've curated options that keep your premium at {premium}. {incentives}\n\nIf cost was a concern due to '{lapse_reason}', let's review flexible payment dates and see if a loyalty discount applies. {digital_support}\n\nReply to this email or use the Renewal Hub link above to complete everything in a few minutes. I'm here if you'd prefer a quick call.\n\nWarm regards,\nPolicy Renewal Team",
+  "SMS": "{customer_name}, your {policy_type} renews on {renewal_date}. {incentives} Reply YES for a quick renewal link or call us if '{lapse_reason}' is still a concern.",
+  "Phone": "Call Script:\n1. Greet {customer_name} and confirm satisfaction with {policy_type}.\n2. Acknowledge lapse reason: {lapse_reason}.\n3. Share tailored offer: {incentives}.\n4. Highlight {digital_support} for self-service.\n5. Guide through renewal before {renewal_date}.",
+  "In-App": "🔔 Renewal reminder: Your {policy_type} renews on {renewal_date}. {incentives}\nTap to explore options tailored for {segment}. We're addressing '{lapse_reason}' with flexible choices."
+}

--- a/configs/segment_strategies.json
+++ b/configs/segment_strategies.json
@@ -1,0 +1,18 @@
+{
+  "Young Families": {
+    "incentives": "We've added a bundled child safety add-on at no extra cost and can split the premium into bi-weekly payments.",
+    "digital_support": "The mobile app now supports co-browsing so we can finalize the renewal together in minutes."
+  },
+  "Mid-Life Planners": {
+    "incentives": "Lock in your rate for the next 24 months and earn 1.5x reward points on timely payments.",
+    "digital_support": "Access a personalized dashboard comparing this year's coverage upgrades in the Renewal Hub."
+  },
+  "Pre-Retirees": {
+    "incentives": "Qualify for a 10% loyalty credit and free annual policy reviews aligned with retirement milestones.",
+    "digital_support": "Schedule a video check-in or chat with an advisor directly inside the portal."
+  },
+  "Small Business Owners": {
+    "incentives": "Bundle your business liability and workers' comp for up to 18% savings, plus priority claims handling.",
+    "digital_support": "We offer after-hours callbacks and a guided renewal workflow tailored for business owners."
+  }
+}

--- a/data/synthetic_policy_customers.csv
+++ b/data/synthetic_policy_customers.csv
@@ -1,0 +1,51 @@
+customer_id,name,age,segment,policy_type,premium,renewal_date,last_interaction_channel,churn_risk,engagement_score,preferred_channel,lapse_reason
+CUST-00001,Avery Chen,39,Mid-Life Planners,Home Shield,1833.41,2025-08-25,Email,0.60,0.22,Email,Switched providers
+CUST-00002,Kai Nakamura,25,Mid-Life Planners,Business Guard,723.95,2025-09-25,Phone,0.79,0.21,SMS,Forgot to renew
+CUST-00003,Emma Johnson,37,Pre-Retirees,Comprehensive Auto,449.40,2025-10-23,Email,0.41,0.47,Phone,Premium too high
+CUST-00004,Kai Garcia,48,Young Families,LifeSecure 20,2033.22,2025-11-22,Phone,0.59,0.75,Email,Switched providers
+CUST-00005,Jordan O'Neal,30,Small Business Owners,LifeSecure 20,1224.83,2025-10-10,Phone,0.24,0.48,Phone,Premium too high
+CUST-00006,Kai O'Neal,34,Small Business Owners,Business Guard,830.39,2025-09-09,SMS,0.68,0.86,Email,Switched providers
+CUST-00007,Maya D'Souza,41,Young Families,Home Shield,2213.24,2025-08-05,Phone,0.28,0.59,In-App,Switched providers
+CUST-00008,Noah O'Neal,71,Pre-Retirees,Business Guard,2180.32,2025-10-03,In-App,0.41,0.98,SMS,Policy no longer needed
+CUST-00009,Jordan Patel,31,Mid-Life Planners,Home Shield,1952.97,2025-12-01,In-App,0.61,0.50,In-App,Policy no longer needed
+CUST-00010,Kai Patel,67,Young Families,LifeSecure 20,1902.49,2025-09-30,Phone,0.19,0.54,In-App,Premium too high
+CUST-00011,Kai Johnson,56,Young Families,LifeSecure 20,2059.59,2025-10-03,SMS,0.23,0.79,Email,Policy no longer needed
+CUST-00012,Ethan Patel,31,Pre-Retirees,LifeSecure 20,764.82,2025-10-18,SMS,0.85,0.94,Email,Forgot to renew
+CUST-00013,Kai Johnson,32,Small Business Owners,Home Shield,819.87,2025-08-14,In-App,0.92,0.92,SMS,Financial hardship
+CUST-00014,Maya Williams,57,Small Business Owners,Comprehensive Auto,783.00,2025-11-07,Email,0.39,0.66,SMS,Policy no longer needed
+CUST-00015,Avery Garcia,69,Young Families,Home Shield,394.91,2025-09-22,Email,0.83,0.26,SMS,Financial hardship
+CUST-00016,Liam Lopez,32,Small Business Owners,Home Shield,1936.93,2025-11-29,In-App,0.26,0.28,In-App,Financial hardship
+CUST-00017,Sofia Williams,70,Young Families,Comprehensive Auto,380.32,2025-11-13,Phone,0.78,0.29,SMS,Switched providers
+CUST-00018,Ethan Johnson,51,Mid-Life Planners,LifeSecure 20,1244.65,2025-12-12,Email,0.48,0.87,Email,Premium too high
+CUST-00019,Avery Garcia,72,Mid-Life Planners,Home Shield,1123.79,2025-12-13,In-App,0.28,0.51,Email,Switched providers
+CUST-00020,Avery D'Souza,40,Small Business Owners,LifeSecure 20,1159.47,2025-11-02,In-App,0.23,0.43,Email,Policy no longer needed
+CUST-00021,Avery Khan,27,Young Families,Business Guard,1331.13,2025-12-13,SMS,0.15,0.60,SMS,Premium too high
+CUST-00022,Liam D'Souza,31,Mid-Life Planners,Comprehensive Auto,1581.67,2025-08-14,In-App,0.66,0.64,Phone,Financial hardship
+CUST-00023,Maya O'Neal,40,Small Business Owners,Home Shield,1694.13,2025-09-18,Phone,0.49,0.92,Email,Premium too high
+CUST-00024,Zoe Nakamura,30,Young Families,Home Shield,1337.65,2025-11-22,SMS,0.89,0.89,SMS,Financial hardship
+CUST-00025,Noah Williams,58,Pre-Retirees,Comprehensive Auto,1685.91,2025-10-08,Phone,0.89,0.28,SMS,Financial hardship
+CUST-00026,Jordan Lopez,33,Pre-Retirees,LifeSecure 20,1550.38,2025-08-26,Phone,0.27,0.69,Phone,Policy no longer needed
+CUST-00027,Emma Patel,29,Small Business Owners,LifeSecure 20,344.79,2025-11-30,Phone,0.76,0.70,Phone,Switched providers
+CUST-00028,Kai D'Souza,59,Young Families,Comprehensive Auto,411.77,2025-11-18,SMS,0.56,0.85,SMS,Forgot to renew
+CUST-00029,Avery Chen,47,Young Families,LifeSecure 20,701.66,2025-08-29,SMS,0.67,0.48,In-App,Policy no longer needed
+CUST-00030,Liam Johnson,35,Small Business Owners,Comprehensive Auto,635.63,2025-09-05,Phone,0.77,0.52,SMS,Financial hardship
+CUST-00031,Jordan D'Souza,26,Small Business Owners,Home Shield,679.08,2025-09-06,In-App,0.40,0.84,SMS,Switched providers
+CUST-00032,Liam D'Souza,45,Pre-Retirees,Comprehensive Auto,2328.81,2025-08-03,Phone,0.40,0.60,Phone,Premium too high
+CUST-00033,Emma Johnson,61,Pre-Retirees,Comprehensive Auto,483.07,2025-08-26,In-App,0.39,0.81,In-App,Policy no longer needed
+CUST-00034,Jordan D'Souza,60,Mid-Life Planners,LifeSecure 20,345.43,2025-12-05,In-App,0.10,0.92,SMS,Financial hardship
+CUST-00035,Jordan Khan,63,Pre-Retirees,Comprehensive Auto,1797.47,2025-11-15,Phone,0.53,0.72,Phone,Forgot to renew
+CUST-00036,Kai Johnson,36,Small Business Owners,Business Guard,1706.23,2025-10-11,SMS,0.62,0.43,Email,Financial hardship
+CUST-00037,Liam D'Souza,61,Pre-Retirees,Business Guard,1199.84,2025-10-09,SMS,0.53,0.82,SMS,Premium too high
+CUST-00038,Kai Nakamura,45,Young Families,Home Shield,1696.51,2025-10-08,SMS,0.79,0.31,Email,Switched providers
+CUST-00039,Zoe Garcia,53,Small Business Owners,Home Shield,1794.44,2025-11-26,In-App,0.52,0.39,Email,Premium too high
+CUST-00040,Liam Johnson,68,Small Business Owners,Comprehensive Auto,1448.42,2025-11-13,Email,0.49,0.83,Phone,Forgot to renew
+CUST-00041,Sofia Lopez,52,Mid-Life Planners,Business Guard,1217.65,2025-12-04,SMS,0.81,0.42,In-App,Switched providers
+CUST-00042,Ethan Garcia,69,Pre-Retirees,Home Shield,834.19,2025-10-06,Phone,0.86,0.26,SMS,Switched providers
+CUST-00043,Noah O'Neal,28,Small Business Owners,Business Guard,961.39,2025-11-03,In-App,0.45,0.36,In-App,Forgot to renew
+CUST-00044,Avery Nakamura,48,Small Business Owners,Comprehensive Auto,2276.89,2025-12-24,Phone,0.74,0.87,In-App,Policy no longer needed
+CUST-00045,Zoe O'Neal,55,Mid-Life Planners,LifeSecure 20,1187.05,2025-12-14,Email,0.43,0.72,In-App,Switched providers
+CUST-00046,Noah Nakamura,58,Young Families,Business Guard,1522.57,2025-11-24,Email,0.17,0.53,In-App,Switched providers
+CUST-00047,Emma D'Souza,44,Mid-Life Planners,Business Guard,952.72,2025-08-09,In-App,0.34,0.94,In-App,Financial hardship
+CUST-00048,Ethan Patel,71,Young Families,LifeSecure 20,732.08,2025-08-17,Email,0.76,0.71,Email,Switched providers
+CUST-00049,Avery Nakamura,33,Mid-Life Planners,Home Shield,1268.16,2025-09-17,Email,0.58,0.37,Phone,Financial hardship
+CUST-00050,Zoe Nakamura,71,Young Families,Home Shield,2324.15,2025-09-08,Email,0.59,0.92,In-App,Forgot to renew

--- a/src/generate_synthetic_data.py
+++ b/src/generate_synthetic_data.py
@@ -1,0 +1,131 @@
+"""Utility for generating synthetic policy renewal data."""
+from __future__ import annotations
+
+import argparse
+import random
+from dataclasses import asdict, dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from typing import List
+
+import csv
+
+SEGMENTS = [
+    "Young Families",
+    "Mid-Life Planners",
+    "Pre-Retirees",
+    "Small Business Owners",
+]
+
+PRODUCTS = [
+    "Comprehensive Auto",
+    "Home Shield",
+    "LifeSecure 20",
+    "Business Guard",
+]
+
+CHANNELS = ["Email", "SMS", "Phone", "In-App"]
+
+REASONS_FOR_LAPSE = [
+    "Premium too high",
+    "Switched providers",
+    "Financial hardship",
+    "Forgot to renew",
+    "Policy no longer needed",
+]
+
+@dataclass
+class CustomerRecord:
+    customer_id: str
+    name: str
+    age: int
+    segment: str
+    policy_type: str
+    premium: float
+    renewal_date: date
+    last_interaction_channel: str
+    churn_risk: float
+    engagement_score: float
+    preferred_channel: str
+    lapse_reason: str
+
+    def to_row(self) -> List[str]:
+        data = asdict(self)
+        data["renewal_date"] = self.renewal_date.isoformat()
+        data["premium"] = f"{self.premium:.2f}"
+        data["churn_risk"] = f"{self.churn_risk:.2f}"
+        data["engagement_score"] = f"{self.engagement_score:.2f}"
+        return list(data.values())
+
+
+def _random_name() -> str:
+    first_names = ["Avery", "Jordan", "Noah", "Liam", "Emma", "Maya", "Sofia", "Ethan", "Kai", "Zoe"]
+    last_names = ["Patel", "Garcia", "Johnson", "O'Neal", "Chen", "Khan", "D'Souza", "Williams", "Lopez", "Nakamura"]
+    return f"{random.choice(first_names)} {random.choice(last_names)}"
+
+
+def _generate_record(idx: int) -> CustomerRecord:
+    today = date.today()
+    renewal_window = random.randint(-60, 90)
+    return CustomerRecord(
+        customer_id=f"CUST-{idx:05d}",
+        name=_random_name(),
+        age=random.randint(24, 72),
+        segment=random.choice(SEGMENTS),
+        policy_type=random.choice(PRODUCTS),
+        premium=random.uniform(250.0, 2400.0),
+        renewal_date=today + timedelta(days=renewal_window),
+        last_interaction_channel=random.choice(CHANNELS),
+        churn_risk=random.uniform(0.1, 0.95),
+        engagement_score=random.uniform(0.2, 0.98),
+        preferred_channel=random.choice(CHANNELS),
+        lapse_reason=random.choice(REASONS_FOR_LAPSE),
+    )
+
+
+def generate_dataset(size: int) -> List[CustomerRecord]:
+    return [_generate_record(i) for i in range(1, size + 1)]
+
+
+def write_csv(records: List[CustomerRecord], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    header = [
+        "customer_id",
+        "name",
+        "age",
+        "segment",
+        "policy_type",
+        "premium",
+        "renewal_date",
+        "last_interaction_channel",
+        "churn_risk",
+        "engagement_score",
+        "preferred_channel",
+        "lapse_reason",
+    ]
+    with output_path.open("w", newline="", encoding="utf-8") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(header)
+        for record in records:
+            writer.writerow(record.to_row())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate synthetic policy renewal data")
+    parser.add_argument("--size", type=int, default=200, help="Number of synthetic customer records")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("data/synthetic_policy_customers.csv"),
+        help="Destination CSV path",
+    )
+    args = parser.parse_args()
+
+    random.seed(42)
+    records = generate_dataset(args.size)
+    write_csv(records, args.output)
+    print(f"Generated {len(records)} customer records at {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/policy_renewal_agent.py
+++ b/src/policy_renewal_agent.py
@@ -1,0 +1,116 @@
+"""Policy Renewal Agent for personalized customer engagement."""
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+TEMPLATE_PATH = Path("configs/channel_templates.json")
+STRATEGY_PATH = Path("configs/segment_strategies.json")
+
+
+@dataclass
+class Customer:
+    customer_id: str
+    name: str
+    age: int
+    segment: str
+    policy_type: str
+    premium: float
+    renewal_date: str
+    last_interaction_channel: str
+    churn_risk: float
+    engagement_score: float
+    preferred_channel: str
+    lapse_reason: str
+
+
+class PolicyRenewalAgent:
+    """Agent that prepares tailored outreach strategies for renewals."""
+
+    def __init__(self, template_path: Path = TEMPLATE_PATH, strategy_path: Path = STRATEGY_PATH) -> None:
+        self.templates = self._load_json(template_path)
+        self.strategies = self._load_json(strategy_path)
+
+    @staticmethod
+    def _load_json(path: Path) -> Dict:
+        if not path.exists():
+            raise FileNotFoundError(f"Configuration file not found: {path}")
+        with path.open("r", encoding="utf-8") as file:
+            return json.load(file)
+
+    def load_customers(self, dataset_path: Path) -> List[Customer]:
+        customers: List[Customer] = []
+        with dataset_path.open("r", encoding="utf-8") as csvfile:
+            reader = csv.DictReader(csvfile)
+            for row in reader:
+                customers.append(
+                    Customer(
+                        customer_id=row["customer_id"],
+                        name=row["name"],
+                        age=int(row["age"]),
+                        segment=row["segment"],
+                        policy_type=row["policy_type"],
+                        premium=float(row["premium"]),
+                        renewal_date=row["renewal_date"],
+                        last_interaction_channel=row["last_interaction_channel"],
+                        churn_risk=float(row["churn_risk"]),
+                        engagement_score=float(row["engagement_score"]),
+                        preferred_channel=row["preferred_channel"],
+                        lapse_reason=row["lapse_reason"],
+                    )
+                )
+        return customers
+
+    def _select_template(self, channel: str) -> str:
+        try:
+            return self.templates[channel]
+        except KeyError as exc:
+            raise KeyError(f"No template configured for channel '{channel}'") from exc
+
+    def _compose_context(self, customer: Customer) -> Dict[str, str]:
+        segment_strategy = self.strategies.get(customer.segment, {})
+        incentives = segment_strategy.get("incentives", "")
+        digital_push = segment_strategy.get("digital_support", "")
+        return {
+            "customer_name": customer.name,
+            "policy_type": customer.policy_type,
+            "premium": f"${customer.premium:,.2f}",
+            "renewal_date": customer.renewal_date,
+            "incentives": incentives,
+            "digital_support": digital_push,
+            "lapse_reason": customer.lapse_reason,
+            "segment": customer.segment,
+        }
+
+    def generate_message(self, customer: Customer, channel: Optional[str] = None) -> str:
+        channel = channel or customer.preferred_channel
+        template = self._select_template(channel)
+        context = self._compose_context(customer)
+        message = template.format(**context)
+        return message
+
+    def plan_outreach(self, customers: Iterable[Customer]) -> List[Dict[str, str]]:
+        playbook: List[Dict[str, str]] = []
+        for customer in customers:
+            message = self.generate_message(customer)
+            playbook.append(
+                {
+                    "customer_id": customer.customer_id,
+                    "channel": customer.preferred_channel,
+                    "message": message,
+                    "churn_risk": f"{customer.churn_risk:.2f}",
+                    "engagement_score": f"{customer.engagement_score:.2f}",
+                }
+            )
+        return playbook
+
+    def save_playbook(self, playbook: List[Dict[str, str]], output_path: Path) -> None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as file:
+            json.dump(playbook, file, indent=2)
+
+
+__all__ = ["PolicyRenewalAgent", "Customer"]

--- a/src/run_agent.py
+++ b/src/run_agent.py
@@ -1,0 +1,34 @@
+"""CLI to generate personalized communication playbook."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from policy_renewal_agent import PolicyRenewalAgent
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create a policy renewal outreach playbook")
+    parser.add_argument(
+        "--customers",
+        type=Path,
+        default=Path("data/synthetic_policy_customers.csv"),
+        help="Path to customer CSV dataset",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("comms/outreach_playbook.json"),
+        help="Where to store the generated playbook",
+    )
+    args = parser.parse_args()
+
+    agent = PolicyRenewalAgent()
+    customers = agent.load_customers(args.customers)
+    playbook = agent.plan_outreach(customers)
+    agent.save_playbook(playbook, args.output)
+    print(f"Saved {len(playbook)} outreach plans to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add synthetic data generator and baseline dataset for policy renewal engagement
- implement configurable policy renewal agent with channel templates and segment strategies
- document workflow and include sample outreach playbook for quick demonstrations

## Testing
- `python src/generate_synthetic_data.py --size 50 --output data/synthetic_policy_customers.csv`
- `python src/run_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68d64f80b9488330804d926a244d0c22