### PR TITLE
Add knowledge-backed policy renewal chatbot experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This repository contains a prototype "Policy Renewal Agent" that helps insurers 
 - `src/generate_synthetic_data.py` – script to generate synthetic customer and policy data aligned with the use case.
 - `src/policy_renewal_agent.py` – lightweight agent logic that blends segment strategies with channel-specific messaging templates.
 - `src/run_agent.py` – command-line entry point that turns a dataset into a channel-ready outreach playbook.
+- `src/policy_chatbot.py` – knowledge base and chatbot helpers that blend policy insights with customer context.
+- `src/chatbot_cli.py` – interactive chatbot experience for Q&A on renewals.
 - `configs/` – prompt templates and strategies used by the agent.
 - `data/` – synthetic datasets (generated).
 - `comms/` – personalized communication outputs produced by the agent.
@@ -23,6 +25,13 @@ This repository contains a prototype "Policy Renewal Agent" that helps insurers 
    ```
 
 The resulting JSON file contains channel recommendations and tailored communication snippets for every customer.
+
+3. **Launch the interactive renewal chatbot**:
+   ```bash
+   python src/chatbot_cli.py --customer-id CUST-00001
+   ```
+   The chatbot introduces the personalized communication plan for the chosen customer and supports follow-up questions about
+   benefits, renewal steps, discounts, or policy specifics sourced from the product document knowledge base.
 
 ## Extending the Agent
 

--- a/data/policy_documents.json
+++ b/data/policy_documents.json
@@ -1,0 +1,130 @@
+{
+  "Home Shield": {
+    "overview": "Home Shield protects the structure of the home, contents and liability with concierge claims support.",
+    "features": [
+      "Extended replacement coverage on the main dwelling",
+      "Smart device monitoring discount for leak and smoke sensors",
+      "One-hour emergency contractor dispatch"
+    ],
+    "benefits": [
+      "Keeps rebuild costs predictable even as materials fluctuate",
+      "Protects valuables with higher sub-limits for electronics and jewelry",
+      "Provides a single claims contact who coordinates vendors and updates"
+    ],
+    "renewal_steps": [
+      "Confirm household updates like renovations or new valuables",
+      "Select the preferred payment frequency or activate autopay",
+      "Review loyalty credit options that offset premium changes",
+      "Complete e-signature in the Renewal Hub or schedule a guided call"
+    ],
+    "support": "Our property specialists are available 24/7 at 1-800-555-0101 and inside the mobile app chat.",
+    "faqs": [
+      {
+        "question": "Does Home Shield cover water damage from burst pipes?",
+        "answer": "Yes, sudden and accidental water damage such as burst pipes is covered. Installing smart leak sensors also unlocks a preventive care discount."
+      },
+      {
+        "question": "Can I adjust the deductible at renewal?",
+        "answer": "Absolutely. During renewal you can increase or decrease your deductible to balance monthly costs with out-of-pocket preferences."
+      },
+      {
+        "question": "What happens if I file multiple claims?",
+        "answer": "Our concierge team reviews prior claims and can map out mitigation tips to keep your coverage in force without surprises."
+      }
+    ]
+  },
+  "Comprehensive Auto": {
+    "overview": "Comprehensive Auto bundles liability, collision, glass and roadside assistance for modern drivers.",
+    "features": [
+      "Accident forgiveness after three claim-free years",
+      "Same-day glass repair scheduling via the mobile app",
+      "Automatic OEM parts for vehicles under five years old"
+    ],
+    "benefits": [
+      "Keeps monthly costs level with smart telematics discounts",
+      "Minimizes downtime thanks to on-demand roadside assistance",
+      "Ensures vehicles are restored to manufacturer standards"
+    ],
+    "renewal_steps": [
+      "Update mileage and driver roster inside the app",
+      "Choose pay-in-full or installment plans with autopay reminders",
+      "Activate available safe-driver or multi-policy rewards",
+      "Confirm ID cards are delivered digitally or mailed"
+    ],
+    "support": "Roadside dispatch is available 24/7 within the app or at 1-800-555-0142.",
+    "faqs": [
+      {
+        "question": "Is rental reimbursement included?",
+        "answer": "Yes, Comprehensive Auto includes up to 30 days of rental reimbursement while covered repairs are completed."
+      },
+      {
+        "question": "How do telematics discounts work?",
+        "answer": "Enroll in the DriveAware program to earn automatic discounts for safe driving behaviors tracked through the mobile app."
+      }
+    ]
+  },
+  "LifeSecure 20": {
+    "overview": "LifeSecure 20 is a versatile term life policy with built-in wellness rewards and conversion options.",
+    "features": [
+      "Guaranteed level premiums for the entire 20-year term",
+      "Wellness reward credits that grow for completing annual screenings",
+      "Conversion privilege into permanent life coverage without new underwriting"
+    ],
+    "benefits": [
+      "Provides stable financial protection for family goals and mortgages",
+      "Rewards healthy habits with premium credits and gift cards",
+      "Gives flexibility to extend coverage when life stages change"
+    ],
+    "renewal_steps": [
+      "Confirm beneficiaries and coverage amounts reflect current goals",
+      "Upload any new wellness activities to maximize credits",
+      "Schedule a consultation to review conversion or rider options",
+      "Sign digitally or request courier pickup for paper forms"
+    ],
+    "support": "Life planning specialists can be booked for evening consultations via the portal or by calling 1-800-555-0175.",
+    "faqs": [
+      {
+        "question": "Can I increase my coverage at renewal?",
+        "answer": "Yes, you can apply for higher coverage or add riders. We'll walk through options that align with your family's goals."
+      },
+      {
+        "question": "What if I miss a premium payment?",
+        "answer": "LifeSecure 20 includes a 30-day grace period and we offer multiple reminders plus autopay to prevent lapses."
+      }
+    ]
+  },
+  "Business Guard": {
+    "overview": "Business Guard packages general liability, commercial property and cyber support for growing enterprises.",
+    "features": [
+      "Cyber incident hotline with first-response coordination",
+      "Business interruption coverage tailored to revenue streams",
+      "Equipment breakdown protection with next-day vendor dispatch"
+    ],
+    "benefits": [
+      "Protects cash flow by covering downtime and quick vendor recovery",
+      "Pairs with HR advisory services to prevent workplace incidents",
+      "Offers proactive cyber monitoring with annual security reviews"
+    ],
+    "renewal_steps": [
+      "Upload updated revenue and payroll figures",
+      "Review bundled coverage tiers for liability, property and cyber",
+      "Designate emergency contacts for our rapid response team",
+      "Finalize renewal digitally with document storage in the portal"
+    ],
+    "support": "Dedicated business specialists respond within two hours at 1-800-555-0198 or through the Business Hub chat.",
+    "faqs": [
+      {
+        "question": "Does Business Guard include cyber insurance?",
+        "answer": "Yes, it includes proactive cyber monitoring plus breach response coverage up to your selected limit."
+      },
+      {
+        "question": "Can I customize coverage for contractors?",
+        "answer": "Absolutely. We can add additional insured endorsements for contractors and partners during renewal."
+      },
+      {
+        "question": "What documentation is needed at renewal?",
+        "answer": "Upload updated financials, equipment lists and any new locations so we can confirm accurate protection levels."
+      }
+    ]
+  }
+}

--- a/src/chatbot_cli.py
+++ b/src/chatbot_cli.py
@@ -1,0 +1,80 @@
+"""Command-line interface for the interactive policy renewal chatbot."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict
+
+from policy_chatbot import PolicyKnowledgeBase, PolicyRenewalChatbot
+from policy_renewal_agent import Customer, PolicyRenewalAgent
+
+
+def _load_customers(agent: PolicyRenewalAgent, dataset_path: Path) -> Dict[str, Customer]:
+    customers = agent.load_customers(dataset_path)
+    return {customer.customer_id: customer for customer in customers}
+
+
+def interactive_session() -> None:
+    parser = argparse.ArgumentParser(description="Interact with the policy renewal chatbot")
+    parser.add_argument(
+        "--customers",
+        type=Path,
+        default=Path("data/synthetic_policy_customers.csv"),
+        help="Path to the customer CSV dataset",
+    )
+    parser.add_argument(
+        "--customer-id",
+        type=str,
+        help="Customer ID to start the chat with. If omitted you'll be prompted to choose.",
+    )
+    parser.add_argument(
+        "--policy-docs",
+        type=Path,
+        default=Path("data/policy_documents.json"),
+        help="Path to the product document knowledge base",
+    )
+    args = parser.parse_args()
+
+    agent = PolicyRenewalAgent(product_document_path=args.policy_docs)
+    knowledge_base = PolicyKnowledgeBase(args.policy_docs)
+    customers = _load_customers(agent, args.customers)
+
+    if not customers:
+        raise SystemExit("No customers found in the dataset. Ensure the CSV is populated.")
+
+    customer_id = args.customer_id
+    if not customer_id or customer_id not in customers:
+        print("Available customers:")
+        for cid, record in list(customers.items())[:10]:
+            print(f"  {cid}: {record.name} – {record.policy_type} (renews {record.renewal_date})")
+        if len(customers) > 10:
+            print("  ... (showing first 10) ...")
+        customer_id = input("Enter the customer ID you want to engage: ").strip()
+        if customer_id not in customers:
+            raise SystemExit(f"Customer ID '{customer_id}' not found in dataset.")
+
+    customer = customers[customer_id]
+    chatbot = PolicyRenewalChatbot(agent, knowledge_base)
+    intro_response = chatbot.intro(customer)
+    print("\n" + intro_response.text + "\n")
+    if intro_response.suggested_prompts:
+        print("Try asking:")
+        for prompt in intro_response.suggested_prompts:
+            print(f"  - {prompt}")
+        print()
+
+    while True:
+        user_input = input("You: ").strip()
+        response = chatbot.answer(customer, user_input)
+        print(f"Agent: {response.text}\n")
+        if response.suggested_prompts:
+            print("You can also ask:")
+            for prompt in response.suggested_prompts:
+                print(f"  - {prompt}")
+            print()
+        if user_input.lower() in PolicyRenewalChatbot.EXIT_COMMANDS:
+            break
+
+
+if __name__ == "__main__":
+    interactive_session()

--- a/src/policy_chatbot.py
+++ b/src/policy_chatbot.py
@@ -1,0 +1,196 @@
+"""Interactive chatbot utilities for the policy renewal use case."""
+from __future__ import annotations
+
+import difflib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from policy_renewal_agent import Customer, PolicyRenewalAgent
+
+POLICY_DOC_PATH = Path("data/policy_documents.json")
+
+
+class PolicyKnowledgeBase:
+    """Simple loader and retriever for policy product documents."""
+
+    def __init__(self, document_path: Path = POLICY_DOC_PATH) -> None:
+        self.document_path = document_path
+        if not self.document_path.exists():
+            raise FileNotFoundError(f"Knowledge base not found: {self.document_path}")
+        with self.document_path.open("r", encoding="utf-8") as source:
+            self.documents: Dict[str, Dict[str, object]] = json.load(source)
+
+    def get_document(self, policy_type: str) -> Dict[str, object]:
+        return self.documents.get(policy_type, {})
+
+    def list_policies(self) -> Iterable[str]:
+        return self.documents.keys()
+
+    def _best_faq_match(self, policy_type: str, question: str) -> Optional[str]:
+        document = self.get_document(policy_type)
+        faqs: Iterable[Dict[str, str]] = document.get("faqs", [])  # type: ignore[assignment]
+        best_answer: Optional[str] = None
+        best_score = 0.0
+        for item in faqs:
+            faq_question = item.get("question", "")
+            answer = item.get("answer", "")
+            if not faq_question or not answer:
+                continue
+            score = difflib.SequenceMatcher(
+                None, faq_question.lower(), question.lower()
+            ).ratio()
+            if score > best_score:
+                best_score = score
+                best_answer = answer
+        if best_score >= 0.45:
+            return best_answer
+        return None
+
+    def get_summary(self, policy_type: str) -> str:
+        document = self.get_document(policy_type)
+        return document.get("overview", "") if isinstance(document, dict) else ""
+
+    def search(self, policy_type: str, question: str) -> Optional[str]:
+        """Return the best fitting FAQ answer for a question if available."""
+        return self._best_faq_match(policy_type, question)
+
+
+@dataclass
+class ChatResponse:
+    """Represents a chatbot reply with optional follow-up prompts."""
+
+    text: str
+    suggested_prompts: Optional[List[str]] = None
+
+
+class PolicyRenewalChatbot:
+    """Rule-based chatbot that personalizes responses with customer context."""
+
+    EXIT_COMMANDS = {"quit", "exit", "bye", "close"}
+
+    def __init__(
+        self,
+        agent: PolicyRenewalAgent,
+        knowledge_base: PolicyKnowledgeBase,
+    ) -> None:
+        self.agent = agent
+        self.knowledge_base = knowledge_base
+
+    def _list_to_bullets(self, items: Iterable[str], label: str) -> Optional[str]:
+        cleaned = [item.strip() for item in items if item]
+        if not cleaned:
+            return None
+        joined = "; ".join(cleaned)
+        return f"{label}: {joined}."
+
+    def _benefits_and_features(self, customer: Customer) -> List[str]:
+        document = self.knowledge_base.get_document(customer.policy_type)
+        responses: List[str] = []
+        benefits = document.get("benefits")
+        if isinstance(benefits, list):
+            text = self._list_to_bullets(benefits[:3], "Key benefits")
+            if text:
+                responses.append(text)
+        features = document.get("features")
+        if isinstance(features, list):
+            text = self._list_to_bullets(features[:3], "Standout features")
+            if text:
+                responses.append(text)
+        return responses
+
+    def _renewal_guidance(self, customer: Customer) -> List[str]:
+        document = self.knowledge_base.get_document(customer.policy_type)
+        responses: List[str] = []
+        steps = document.get("renewal_steps")
+        if isinstance(steps, list) and steps:
+            step_text = "; ".join(
+                f"Step {idx + 1}: {step}" for idx, step in enumerate(steps[:4]) if step
+            )
+            responses.append(f"Renewal checklist — {step_text}.")
+        support = document.get("support")
+        if isinstance(support, str) and support:
+            responses.append(support)
+        return responses
+
+    def _segment_incentive(self, customer: Customer) -> Optional[str]:
+        strategy = self.agent.strategies.get(customer.segment, {})
+        incentive = strategy.get("incentives") if isinstance(strategy, dict) else ""
+        if incentive:
+            return f"Because {customer.name} is in the {customer.segment} segment we can offer: {incentive}"
+        return None
+
+    def _compose_intro(self, customer: Customer) -> str:
+        document_summary = self.knowledge_base.get_summary(customer.policy_type)
+        intro_lines = [
+            f"👋 Hi {customer.name}, I'm your renewal guide for the {customer.policy_type} policy.",
+            f"Current premium: ${customer.premium:,.2f} and renewal date: {customer.renewal_date}.",
+        ]
+        if document_summary:
+            intro_lines.append(document_summary)
+        incentive = self._segment_incentive(customer)
+        if incentive:
+            intro_lines.append(incentive)
+        intro_lines.append(
+            "Ask me about benefits, features, pricing, renewal steps or anything else you need clarified."
+        )
+        return "\n".join(intro_lines)
+
+    def intro(self, customer: Customer) -> ChatResponse:
+        message = self.agent.generate_message(customer)
+        intro_text = self._compose_intro(customer)
+        prompt_suggestions = [
+            "What benefits do I keep if I renew?",
+            "How do I finish the renewal steps?",
+            "Are there payment or discount options?",
+        ]
+        combined = f"{intro_text}\n\nHere is a personalized outreach message we prepared:\n{message}"
+        return ChatResponse(text=combined, suggested_prompts=prompt_suggestions)
+
+    def answer(self, customer: Customer, question: str) -> ChatResponse:
+        normalized = question.strip()
+        if not normalized:
+            return ChatResponse(text="Could you share a bit more about what you'd like to know?")
+        lowered = normalized.lower()
+        if lowered in self.EXIT_COMMANDS:
+            return ChatResponse(text="Thanks for chatting. Feel free to reach out any time!", suggested_prompts=[])
+
+        responses: List[str] = []
+        if any(keyword in lowered for keyword in ["benefit", "value", "cover"]):
+            responses.extend(self._benefits_and_features(customer))
+        if any(keyword in lowered for keyword in ["feature", "technology", "service"]):
+            responses.extend(self._benefits_and_features(customer))
+        if any(keyword in lowered for keyword in ["step", "process", "renew", "complete", "finish"]):
+            responses.extend(self._renewal_guidance(customer))
+        if any(keyword in lowered for keyword in ["payment", "discount", "offer", "incentive", "price", "premium"]):
+            incentive = self._segment_incentive(customer)
+            if incentive:
+                responses.append(incentive)
+            responses.append(
+                f"We can review flexible billing schedules so the ${customer.premium:,.2f} premium fits your budget."
+            )
+        knowledge_hit = self.knowledge_base.search(customer.policy_type, lowered)
+        if knowledge_hit:
+            responses.append(knowledge_hit)
+
+        if not responses:
+            summary = self.knowledge_base.get_summary(customer.policy_type)
+            if summary:
+                responses.append(summary)
+            responses.append(
+                "You can ask about coverage, renewal steps, pricing or request to connect with a human advisor."
+            )
+
+        follow_ups: List[str] = []
+        if "renew" not in lowered:
+            follow_ups.append("Could you outline the renewal steps?")
+        if "benefit" not in lowered and "feature" not in lowered:
+            follow_ups.append("What are the standout benefits?")
+        if "discount" not in lowered and "payment" not in lowered:
+            follow_ups.append("Do you have any loyalty credits or payment support?")
+
+        return ChatResponse(text="\n\n".join(responses), suggested_prompts=follow_ups)
+
+
+__all__ = ["PolicyKnowledgeBase", "PolicyRenewalChatbot", "ChatResponse"]

--- a/src/policy_renewal_agent.py
+++ b/src/policy_renewal_agent.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional
 
+PRODUCT_DOCS_PATH = Path("data/policy_documents.json")
+
 TEMPLATE_PATH = Path("configs/channel_templates.json")
 STRATEGY_PATH = Path("configs/segment_strategies.json")
 
@@ -30,9 +32,21 @@ class Customer:
 class PolicyRenewalAgent:
     """Agent that prepares tailored outreach strategies for renewals."""
 
-    def __init__(self, template_path: Path = TEMPLATE_PATH, strategy_path: Path = STRATEGY_PATH) -> None:
+    def __init__(
+        self,
+        template_path: Path = TEMPLATE_PATH,
+        strategy_path: Path = STRATEGY_PATH,
+        product_document_path: Optional[Path] = PRODUCT_DOCS_PATH,
+    ) -> None:
         self.templates = self._load_json(template_path)
         self.strategies = self._load_json(strategy_path)
+        self.product_docs: Dict[str, Dict[str, object]] = {}
+        if product_document_path is not None:
+            if not product_document_path.exists():
+                raise FileNotFoundError(
+                    f"Configuration file not found: {product_document_path}"
+                )
+            self.product_docs = self._load_json(product_document_path)
 
     @staticmethod
     def _load_json(path: Path) -> Dict:
@@ -85,6 +99,63 @@ class PolicyRenewalAgent:
             "segment": customer.segment,
         }
 
+    def _product_document(self, policy_type: str) -> Dict[str, object]:
+        return self.product_docs.get(policy_type, {})
+
+    @staticmethod
+    def _join_items(label: str, items: Iterable[str]) -> str:
+        listed = [item.strip() for item in items if item]
+        if not listed:
+            return ""
+        return f"{label}: " + "; ".join(listed)
+
+    def _build_value_proposition(self, customer: Customer) -> str:
+        document = self._product_document(customer.policy_type)
+        parts: List[str] = []
+        benefits = document.get("benefits")
+        if isinstance(benefits, list):
+            snippet = self._join_items("Benefits", benefits[:3])
+            if snippet:
+                parts.append(snippet)
+        features = document.get("features")
+        if isinstance(features, list):
+            snippet = self._join_items("Features customers love", features[:3])
+            if snippet:
+                parts.append(snippet)
+        incentives = self.strategies.get(customer.segment, {}).get("incentives", "")
+        if incentives:
+            parts.append(f"Segment incentive: {incentives}")
+        overview = document.get("overview")
+        if not parts and isinstance(overview, str):
+            parts.append(overview)
+        if not parts:
+            parts.append(
+                f"Reinforce how {customer.policy_type} keeps {customer.name}'s needs covered."
+            )
+        return " ".join(parts)
+
+    def _build_next_best_actions(self, customer: Customer) -> str:
+        document = self._product_document(customer.policy_type)
+        steps = document.get("renewal_steps")
+        parts: List[str] = []
+        if isinstance(steps, list) and steps:
+            numbered = "; ".join(
+                f"Step {idx + 1}: {step}" for idx, step in enumerate(steps[:4]) if step
+            )
+            if numbered:
+                parts.append(numbered)
+        support = document.get("support")
+        if isinstance(support, str) and support:
+            parts.append(support)
+        digital_support = self.strategies.get(customer.segment, {}).get(
+            "digital_support", ""
+        )
+        if digital_support:
+            parts.append(digital_support)
+        if not parts:
+            parts.append("Offer to co-browse the renewal steps and confirm coverage updates.")
+        return " ".join(parts)
+
     def generate_message(self, customer: Customer, channel: Optional[str] = None) -> str:
         channel = channel or customer.preferred_channel
         template = self._select_template(channel)
@@ -103,6 +174,8 @@ class PolicyRenewalAgent:
                     "message": message,
                     "churn_risk": f"{customer.churn_risk:.2f}",
                     "engagement_score": f"{customer.engagement_score:.2f}",
+                    "value_proposition": self._build_value_proposition(customer),
+                    "next_best_actions": self._build_next_best_actions(customer),
                 }
             )
         return playbook


### PR DESCRIPTION
## Summary
- extend the policy renewal agent to read product documents so outreach plans now highlight value propositions and next best actions for each customer
- add a reusable knowledge base plus rule-based chatbot that personalizes answers with customer context and segment incentives
- document the workflow update in the README and seed structured policy content for the chatbot and outreach generator

## Testing
- python src/run_agent.py --customers data/synthetic_policy_customers.csv --output comms/outreach_playbook.json
- python src/chatbot_cli.py --customer-id CUST-00001 <<'EOF'
benefits
exit
EOF
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d65c4087bc8330a2d1544e264bffe2