### PR TITLE
Add default GenAI Lab endpoint configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ The resulting JSON file contains channel recommendations and tailored communicat
    The chatbot introduces the personalized communication plan for the chosen customer and supports follow-up questions about
    benefits, renewal steps, discounts, or policy specifics sourced from the product document knowledge base.
 
+   By default the application now targets the GenAI Lab inference endpoint (`https://genailab.tcs.in`) using the shared
+   hackathon API key.  You can override the endpoint or credentials by setting the `AZURE_OPENAI_ENDPOINT` /
+   `AZURE_OPENAI_API_KEY` or `AZURE_AI_ENDPOINT` / `AZURE_AI_API_KEY` environment variables before launching the chatbot.
+
 ## Extending the Agent
 
 - Plug the playbook into local SLMs (e.g., Llama-3.2-3b-it) or Azure-hosted models for final copy polishing.

--- a/src/llm_clients.py
+++ b/src/llm_clients.py
@@ -48,9 +48,11 @@ class ProviderConfig:
     api_version_env: str
     default_api_version: str
     path_template: str
+    default_endpoint: Optional[str] = None
+    default_api_key: Optional[str] = None
 
     def resolve_endpoint(self) -> str:
-        endpoint = os.getenv(self.endpoint_env)
+        endpoint = os.getenv(self.endpoint_env, self.default_endpoint)
         if not endpoint:
             raise LLMConfigurationError(
                 f"Set the {self.endpoint_env} environment variable to call this model."
@@ -58,7 +60,7 @@ class ProviderConfig:
         return endpoint.rstrip("/")
 
     def resolve_key(self) -> str:
-        key = os.getenv(self.api_key_env)
+        key = os.getenv(self.api_key_env, self.default_api_key)
         if not key:
             raise LLMConfigurationError(
                 f"Set the {self.api_key_env} environment variable to call this model."
@@ -76,6 +78,8 @@ PROVIDERS: Mapping[str, ProviderConfig] = {
         api_version_env="AZURE_OPENAI_API_VERSION",
         default_api_version="2024-02-15-preview",
         path_template="/openai/deployments/{deployment}/chat/completions",
+        default_endpoint="https://genailab.tcs.in",
+        default_api_key="sk-LauROPagAqV4OtVxMbYjBw",
     ),
     "azure_ai": ProviderConfig(
         endpoint_env="AZURE_AI_ENDPOINT",
@@ -83,6 +87,8 @@ PROVIDERS: Mapping[str, ProviderConfig] = {
         api_version_env="AZURE_AI_API_VERSION",
         default_api_version="2024-05-01-preview",
         path_template="/openai/deployments/{deployment}/chat/completions",
+        default_endpoint="https://genailab.tcs.in",
+        default_api_key="sk-LauROPagAqV4OtVxMbYjBw",
     ),
 }
 


### PR DESCRIPTION
## Summary
- allow Azure provider configuration to fall back to the shared GenAI Lab endpoint and key
- document the default endpoint and how to override it in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d666498b98833097cf29423447cfb0