### PR TITLE
Enable LLM-powered realtime CLI chat

### DIFF
--- a/src/llm_clients.py
+++ b/src/llm_clients.py
@@ -30,6 +30,12 @@ from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional
 
 import requests
 
+# Temporarily suppress SSL verification errors in local environments where
+# self-signed certificates are used.  The requests issued by this module are
+# configured to skip certificate validation until the deployment provides
+# trusted certificates.
+requests.packages.urllib3.disable_warnings()  # type: ignore[attr-defined]
+
 
 class LLMConfigurationError(RuntimeError):
     """Raised when an LLM call cannot be prepared due to misconfiguration."""
@@ -181,7 +187,13 @@ class AzureChatClient:
         if "max_tokens" in kwargs:
             payload["max_tokens"] = kwargs["max_tokens"]
 
-        response = requests.post(url, headers=headers, json=payload, timeout=60)
+        response = requests.post(
+            url,
+            headers=headers,
+            json=payload,
+            timeout=60,
+            verify=False,
+        )
         if response.status_code >= 400:
             raise RuntimeError(
                 f"Model request failed ({response.status_code}): {response.text}"


### PR DESCRIPTION
## Summary
- default the CLI chatbot to the azure/genailab-maas-gpt-4o deployment for live conversations
- layer Azure chat completions on top of the rule-based customer guidance to deliver realtime replies
- temporarily disable SSL verification for outbound model requests to work around local certificate errors

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d66cce95488330a46b615b1e09b1ca