### PR TITLE
Enhance policy chatbot with customer detail responses

### DIFF
--- a/src/gui_chatbot.py
+++ b/src/gui_chatbot.py
@@ -231,7 +231,10 @@ def main() -> None:
             st.info("Session ended. Start a new session from the sidebar to continue.")
         else:
             user_prompt: Optional[str] = st.session_state.pop("pending_prompt", None)
-            user_prompt = st.chat_input("Ask about benefits, pricing, or renewal steps", key="chat_input") or user_prompt
+            user_prompt = st.chat_input(
+                "Ask about customer details, coverage, discounts, or renewal steps",
+                key="chat_input",
+            ) or user_prompt
 
             if user_prompt:
                 _append_message("user", user_prompt)


### PR DESCRIPTION
## Summary
- expand the policy chatbot with customer attribute lookups, coverage and discount highlights, and friendlier fallbacks
- expose helper accessors in the policy knowledge base and refresh onboarding prompts for the richer guidance
- update the Streamlit chat prompt to invite questions about customer details and policy support topics

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d67098b7d4833089109ce07c5fc16d